### PR TITLE
generateandsign: add param to choose from which MO Root the issued CC…

### DIFF
--- a/specification/components/parameters/cpsV2GRootCertificateFingerprintParam.v1.json
+++ b/specification/components/parameters/cpsV2GRootCertificateFingerprintParam.v1.json
@@ -2,6 +2,6 @@
   "title": "cpsV2GRootCertificateFingerprintParamV1",
   "description": "The SHA256 Fingerprint of the desired V2G root CA which shall was used to sign these data with the regarding CPS signing certificate. Its optional. If not given, the CPS will decide which CPS signing V2G PKI will be renurned\n",
   "type": "string",
-  "pattern": "^[0-9a-fA-F]{8}\\-([0-9a-fA-F]{4}\\-){3}[0-9a-fA-F]{12}$",
-  "example": "896b6655-180e-4304-b642-606bb00df8f0"
+  "pattern": "^[0-9a-fA-F]{64}$",
+  "example": "311f28ff13da6d75f836ac10644b34273da99564c600a191fb3737d50562a4f1"
 }

--- a/specification/components/parameters/moRootCertificateFingerprintParam.v1.json
+++ b/specification/components/parameters/moRootCertificateFingerprintParam.v1.json
@@ -2,6 +2,6 @@
   "title": "moRootCertificateFingerprintParamV1",
   "description": "The SHA256 Fingerprint of the desired MO root CA from which the CC will derive. It is optional. If not given, the PKI service operator will decide from which MO Root CA the issued CC will derive\n",
   "type": "string",
-  "pattern": "^[0-9a-fA-F]{8}\\-([0-9a-fA-F]{4}\\-){3}[0-9a-fA-F]{12}$",
-  "example": "896b6655-180e-4304-b642-606bb00df8f0"
+  "pattern": "^[0-9a-fA-F]{64}$",
+  "example": "311f28ff13da6d75f836ac10644b34273da99564c600a191fb3737d50562a4f1"
 }

--- a/specification/components/parameters/moRootCertificateFingerprintParam.v1.json
+++ b/specification/components/parameters/moRootCertificateFingerprintParam.v1.json
@@ -1,0 +1,7 @@
+{
+  "title": "moRootCertificateFingerprintParamV1",
+  "description": "The SHA256 Fingerprint of the desired MO root CA from which the CC will derive. It is optional. If not given, the PKI service operator will decide from which MO Root CA the issued CC will derive\n",
+  "type": "string",
+  "pattern": "^[0-9a-fA-F]{8}\\-([0-9a-fA-F]{4}\\-){3}[0-9a-fA-F]{12}$",
+  "example": "896b6655-180e-4304-b642-606bb00df8f0"
+}

--- a/specification/components/requestBodies/generateAndSignContractDataReq.v1.json
+++ b/specification/components/requestBodies/generateAndSignContractDataReq.v1.json
@@ -42,6 +42,9 @@
         "cpsV2GRootCertificateFingerprint": {
             "$ref": "../parameters/cpsV2GRootCertificateFingerprintParam.v1.json"
         },
+        "moRootCertificateFingerprint": {
+            "$ref": "../parameters/moRootCertificateFingerprintParam.v1.json"
+        },
         "metaData": {
             "type": "string",
             "description": "Placeholder for future adaption"


### PR DESCRIPTION
As discuss in today's workshop, we want to add the possibility for the EMSP to select from which MO root the generated CC will derive.