### PR TITLE
SignContractData : creation of a clear CCB object and passing it in SignContractDataReq.v1.json

### DIFF
--- a/specification/components/requestBodies/signContractDataReq.v1.json
+++ b/specification/components/requestBodies/signContractDataReq.v1.json
@@ -3,14 +3,8 @@
     "description": "",
     "type": "object",
     "properties": {
-        "contractCertificateData": {
-            "$ref": "../schemas/contractCertificateData.v1.json"
-        },
-        "pcid": {
-            "$ref": "../parameters/pcidParam.v1.json"
-        },
-        "emaid": {
-            "$ref": "../parameters/emaidParam.v1.json"
+        "contractCertificateBundle": {
+            "$ref": "../schemas/contractCertificateBundle.v1.json"
         },
         "xsdMsgDefNamespace": {
             "$ref": "../parameters/xsdMsgDefNamespaceParam.v1.json"
@@ -20,7 +14,7 @@
         }
     },
     "required": [
-        "contractCertificteData",
+        "contractCertificateBundle",
         "xsdMsgDefNamespace"
     ]
 }

--- a/specification/components/schemas/contractCertificateBundle.v1.json
+++ b/specification/components/schemas/contractCertificateBundle.v1.json
@@ -1,11 +1,11 @@
 {
-    "title": "ContractCertificateDataV1",
-    "description": "Contract Data consisting of the contract certificate and its chain not including the MO Root CA itself. Furthermore the encrypted contract private key and the DH Public Key as descirbed in the ISO 15118 is included ",
+    "title": "contractCertificateBundleV1",
+    "description": "Contract certificate bundle consisting of the contract certificate and its chain not including the MO Root CA itself. Furthermore the encrypted contract private key and the DH Public Key as descirbed in the ISO 15118 is included ",
     "type": "object",
     "x-examples": {
         "example-1": {
             "contractCertificateChain": {
-                "ertificate": "",
+                "certificate": "",
                 "subCa2Certificate": "",
                 "subCa1Certificate": "",
                 "contractSignatureEncryptedPrivateKey": "PD5/v8Z005yianHegxvs2vE/uRPOjBaP4byhAVwyj6APg6BFOZexCpCacHTxgELr",
@@ -14,6 +14,12 @@
             }
     },
     "properties": {
+        "pcid": {
+            "$ref": "../parameters/pcidParam.v1.json"
+        },
+        "emaid": {
+            "$ref": "../parameters/emaidParam.v1.json"
+        },
         "contractCertificateChain": {
             "$ref": "./certificateChain.v1.json"
         },


### PR DESCRIPTION
SignContractData needs the full bundle as an input to sign it and therefore turning it into a SCCB. 
I created a clear ContractCertificateBundle object  by renaming the ContractCertificateDataV1.json object that was maybe meant for that but unused and completed that object with the PCID and EMAID that are also components of the CCB. 

