### PR TITLE
PKI services : Addition of a dedicated certificate revocation service

### DIFF
--- a/specification/apis/pki/pki.api.v1.json
+++ b/specification/apis/pki/pki.api.v1.json
@@ -26,6 +26,9 @@
     },
     "/est/cacerts": {
       "$ref": "./pki.api.v1.caCerts.json"
+    },
+    "/pki/revokeCertificate" : {
+      "$ref": "./pki.api.v1.revokeCert.json"
     }
   }
 }

--- a/specification/apis/pki/pki.api.v1.revokeCert.json
+++ b/specification/apis/pki/pki.api.v1.revokeCert.json
@@ -1,0 +1,44 @@
+{
+  "post": {
+    "summary": "RevokeCert",
+    "operationId": "revokeCertV1",
+    "tags": [
+      "RevokeCert"
+    ],
+    "description": "Revocation service for leaf certificates (SECC Certificate, Contract Certificate, OEM Contract Certificate, OEM Vehicle Certificate).\n\n *NB: A PKI certificate subscriber can only ask the revocation on one of his own certificates.* \n\n *NB2: A certificate can be revoked only by the Certificate Authority that delivered it.*",
+    "requestBody": {
+      "content": {
+        "application/json": {
+          "schema": {
+            "$ref": "../../components/requestBodies/revokeCertificateReq.v1.json"
+          },
+          "examples": {
+            "example": {
+              "value": {
+                "certificate": "MIIC8jCCApegAwIBAgIIVgSOEtL5U+owCgYIKoZIzj0EAwIwbjElMCMGA1UEAwwcU3ViQ0EyLUEtZU1TUF9Gb3JfQ0MtR2VuZXJpYzEMMAoGA1UECwwDU1RHMQ8wDQYDVQQKDAZHSVJFVkUxGTAXBgoJkiaJk/IsZAEZFglTdWJDQTItQ0MxCzAJBgNVBAYTAkZSMB4XDTI0MDEyMjEwMDE0NVoXDTI2MDEyMTEwMDE0NFowOTEYMBYGA1UEAwwPVFVBQUJjQXoyQks3SlJhMQwwCgYDVQQLDANTVEcxDzANBgNVBAoMBkdJUkVWRTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAJdgL7lS8wUMIy8IOiM6SpH1Bjp5GWKFFCYx55bBoHC7yyo2b+GcQSnGRMKaB4F5t06fk1w9+P7uehhjmXwLFGjggFSMIIBTjAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFMgAjDsX1OyW40YHz/CTyEQx8iGrMFEGCCsGAQUFBwEBBEUwQzBBBggrBgEFBQcwAYY1aHR0cDovL29jc3AudGttZ2lydi5ldzEuYWlzLXN0ZzAzLmFjbG91ZC5nZW1hbHRvLmNvbS8wgZoGA1UdHwSBkjCBjzCBjKCBiaCBhoaBg2h0dHA6Ly9jcmwudGttZ2lydi5ldzEuYWlzLXN0ZzAzLmFjbG91ZC5nZW1hbHRvLmNvbTo4MC9jcmwvaXNzdWVyL0NOPVN1YkNBMi1BLWVNU1BfRm9yX0NDLUdlbmVyaWMsT1U9U1RHLE89R0lSRVZFLERDPVN1YkNBMi1DQyxDPUZSMB0GA1UdDgQWBBQ/vmRczFWeeSwQl28yZuABoCCj2jAOBgNVHQ8BAf8EBAMCA+gwCgYIKoZIzj0EAwIDSQAwRgIhAP13OVb18cdam6r+pbmqzy4n7332OZUMt7qK2W1a7Ns6AiEA0QKHeNa2ZSuv6jIhr1Z01XZUZHOROA1o2s/dNvfBKp8=",
+                "revocationReason": "privilegeWithdrawn"
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "OK"
+      },
+      "400": {
+        "description": "Bad Request"
+      },
+      "401": {
+        "description": "Unauthorized"
+      },
+      "403": {
+        "description": "Forbidden"
+      },
+      "5XX": {
+        "description": "Internal Server Error"
+      }
+    }
+  }
+}

--- a/specification/components/requestBodies/revokeCertificateReq.v1.json
+++ b/specification/components/requestBodies/revokeCertificateReq.v1.json
@@ -1,0 +1,21 @@
+{
+  "title": "RevokeCertificateDataReqV1",
+  "type": "object",
+  "description": "",
+  "properties": {
+    "certificate": {
+      "type": "string",
+      "description": "Certificate in base64 encoded PEM form",
+      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+    },
+    "revocationReason": {
+      "type": "string",
+      "enum": ["privilegeWithdrawn", "affiliationChanged", "superseded", "unspecified", "keyCompromise", "aACompromise", "cessationOfOperation"],
+      "description" : "Description of revocation reasons :\n\n* `privilegeWithdrawn` - indicates that the privileges granted to the subject of the certificate have been withdrawn \n\n* `affiliationChanged` - indicates that the subject's name or other information has changed.\n\n* `superseded` - indicates that the certificate has been superseded.\n\n* `unspecified` - indicates that it is unspecified as to why the certificate has been revoked.\n\n* `keyCompromise` - indicates that it is known or suspected that the certificate subject's private key has been compromised.\n\n* `aACompromise` - indicates that it is known or suspected that the certificate subject's private key has been compromised. It applies to authority attribute (AA) certificates only.\n\n* `cessationOfOperation` - indicates that the certificate is no longer needed."
+    }
+  },
+  "required": [
+    "certificate",
+    "revocationReason"
+  ]
+}


### PR DESCRIPTION
Revocation in OPNC today is possible on 2 services that mix pool operations and PKI operations: 
* DeleteSignedContractDataByEmaid: Deletes a CC from a CCP and revokes the CC if the CCP is also the PKI platform that issued it.
* DeleteProvisioningCertificateByPCID: Deletes a PC from a PCP, deletes the CC linked to this PC if the PCP is also a CCP, revokes the CC linked to the PC if the PCP/CCP is also the PKI platform that issued the CC.

This does not cover the revocation of SECC, PC and vehicle certificates and is not proper if the party who delivered the end entity certificate is a pure PKI Platform and not a Certificate Pool. Also the certificate subscriber who wants to revoke one of its certificates can not specify the exact reason of why it want to revoke 

In order to solve this, i propose to add is a dedicated PKI revocation service that will cover revocation request on all end entity certificates (SECC, PC, CC, Vehicle Certificates). 
  



